### PR TITLE
Rspec controller bill admin

### DIFF
--- a/app/controllers/admin/bills_controller.rb
+++ b/app/controllers/admin/bills_controller.rb
@@ -12,7 +12,7 @@ class Admin::BillsController < Admin::BaseController
     @bill.cancel_booking(cancel_params)
     flash.now[:success] = t("bookings.cancel_success")
     render :success_cancel
-  rescue RuntimeError => e
+  rescue RuntimeError, ActiveRecord::RecordInvalid => e
     flash.now[:danger] = e
     render :cancel_valid, status: :unprocessable_entity
   end
@@ -23,7 +23,6 @@ class Admin::BillsController < Admin::BaseController
     else
       flash.now[:error] = t("bookings.confirm_error")
     end
-    redirect_to admin_bills_path
   end
   private
   def ransack_params

--- a/app/views/admin/bills/confirm.turbo_stream.erb
+++ b/app/views/admin/bills/confirm.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.append :flash do%>
+  <%= render "shared/flash_messages"%>
+<%end%>
+<%= turbo_stream.replace dom_id(@bill) do %>
+  <%= render "admin/bills/status", bill: @bill %>
+<%end%>

--- a/spec/requests/admin/bill_spec.rb
+++ b/spec/requests/admin/bill_spec.rb
@@ -1,0 +1,46 @@
+require 'support/admin_shared'
+
+RSpec.describe Admin::BillsController, :admin, type: :controller do
+  let(:booking) { create(:booking) }
+
+  describe "GET #index" do
+    it "returns a success response" do
+      get :index
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #cancel_modal" do
+    it "returns a success response" do
+      get :cancel_modal, as: :turbo_stream, params: { id: booking.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq Mime[:turbo_stream]
+    end
+  end
+
+  describe "POST #submit_cancel" do
+    context "with valid params" do
+      it "cancels the booking" do
+        post :submit_cancel, as: :turbo_stream, params: { id: booking.id, booking: { reason: "TEST" } }
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq Mime[:turbo_stream]
+      end
+    end
+
+    context "with invalid params" do
+      it "renders the new template" do
+        post :submit_cancel, as: :turbo_stream, params: { id: booking.id, booking: { reason: "" } }
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.media_type).to eq Mime[:turbo_stream]
+      end
+    end
+  end
+
+  describe "PATCH #confirm" do
+    it "confirms the booking" do
+      patch :confirm, as: :turbo_stream, params: { id: booking.id }
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq Mime[:turbo_stream]
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets
[- ticket redmine](https://edu-redmine.sun-asterisk.vn/issues/73949)

## WHAT (optional)
- Change number items `completed/total` in admin page.

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)


## Notes (Kiến thức tìm hiểu thêm)
